### PR TITLE
#49 - Fix interaction is undefined in setup command

### DIFF
--- a/handlers/buttonEventHandler.js
+++ b/handlers/buttonEventHandler.js
@@ -40,7 +40,7 @@ class ButtonEventHandler {
                 embeds: this.interaction.message.embeds, // Keep the same embeds
                 components: [] // Remove the components (e.g., buttons, dropdowns, etc.)
             });
-            this.interaction.reply("A recent Update has changed how I identify bots. I am unable to register any votes on messages created before <t:1725855060:F>")
+            this.interaction.reply("A recent Update has changed how I identify votes. I am unable to register any votes on messages created before <t:1725855060:F>")
         }
 
         //get the type from the question using the messageId as the key


### PR DESCRIPTION
(I also fixed a spelling mistake in the button event handler)

There was an "interaction is undefined" error thrown whenever a user chose an announcement channel as part of the /setup command

I fixed this error by extracting the broadbastEval from SetupHandler.action_2 into it's own function (for readability) and making it return a boolean. Now the action_2 function waits for `askOtherShards` to return a boolean, and responds with a success or error message based on that boolean