### PR TITLE
Implement error logging for manager and shards

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -17,11 +17,20 @@ process.on('uncaughtException', (err, origin) => {
     console.error(err);
     console.error(origin);
     logger.error(err.name + "\n" + err.message + "\n" + err.stack);
+    fs.appendFileSync('/tmp/bot_errors.log', `${Date.now()} [SHARD ${client.shard?.ids?.[0] || 'unknown'}]: ${error.stack || error}\n`);
+
+});
+
+process.on('unhandledRejection', (reason, promise) => {
+  fs.appendFileSync('/tmp/bot_errors.log', `${Date.now()} [SHARD ${client.shard?.ids?.[0] || 'unknown'}] Unhandled Rejection: ${reason}\n`);
 });
 
 global.client = new Client({ intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages] });
 client.commands = new Collection();
 
+client.on('error', (error) => {
+  fs.appendFileSync('/tmp/bot_errors.log', `${Date.now()} [CLIENT ${client.shard?.ids?.[0] || 'unknown'}]: ${error.stack || error}\n`);
+});
 
 async function init() {
 

--- a/bot.js
+++ b/bot.js
@@ -25,7 +25,7 @@ process.on('uncaughtException', (err, origin) => {
 });
 
 process.on('unhandledRejection', (reason, promise) => {
-    fs.appendFile('/tmp/bot_errors.log', `${new Date().toISOString()} [SHARD ${client.shard?.ids?.[0] || 'unknown'}] Unhandled Rejection: ${reason}\n`, (writeError) => {
+    fs.appendFile('/tmp/bot_errors.log', `${new Date().toISOString()} [SHARD ${client.shard?.ids?.[0] || 'unknown'}] Unhandled Rejection: ${reason?.stack || util.inspect(reason)}\n`, (writeError) => {
         if (writeError) {
             console.error('Failed to write error to log file:', writeError);
         }

--- a/bot.js
+++ b/bot.js
@@ -17,19 +17,30 @@ process.on('uncaughtException', (err, origin) => {
     console.error(err);
     console.error(origin);
     logger.error(err.name + "\n" + err.message + "\n" + err.stack);
-    fs.appendFileSync('/tmp/bot_errors.log', `${Date.now()} [SHARD ${client.shard?.ids?.[0] || 'unknown'}]: ${error.stack || error}\n`);
-
+    fs.appendFile('/tmp/bot_errors.log', `${new Date().toISOString()} [SHARD ${client.shard?.ids?.[0] || 'unknown'}]: ${err.stack || err}\n`, (writeError) => {
+        if (writeError) {
+            console.error('Failed to write error to log file:', writeError);
+        }
+    });
 });
 
 process.on('unhandledRejection', (reason, promise) => {
-  fs.appendFileSync('/tmp/bot_errors.log', `${Date.now()} [SHARD ${client.shard?.ids?.[0] || 'unknown'}] Unhandled Rejection: ${reason}\n`);
+    fs.appendFile('/tmp/bot_errors.log', `${new Date().toISOString()} [SHARD ${client.shard?.ids?.[0] || 'unknown'}] Unhandled Rejection: ${reason}\n`, (writeError) => {
+        if (writeError) {
+            console.error('Failed to write error to log file:', writeError);
+        }
+    });
 });
 
 global.client = new Client({ intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessages] });
 client.commands = new Collection();
 
 client.on('error', (error) => {
-  fs.appendFileSync('/tmp/bot_errors.log', `${Date.now()} [CLIENT ${client.shard?.ids?.[0] || 'unknown'}]: ${error.stack || error}\n`);
+    fs.appendFile('/tmp/bot_errors.log', `${new Date().toISOString()} [CLIENT ${client.shard?.ids?.[0] || 'unknown'}]: ${error.stack || error}\n`, (writeError) => {
+        if (writeError) {
+            console.error('Failed to write error to log file:', writeError);
+        }
+    });
 });
 
 async function init() {

--- a/index.js
+++ b/index.js
@@ -36,6 +36,17 @@ global.my = {
     environment: 'stage'
 };
 
+const fs = require('fs');
+
+// Catch errors at the manager level
+process.on('uncaughtException', (error) => {
+  fs.appendFileSync('/tmp/bot_errors.log', `${Date.now()} [MANAGER]: ${error.stack || error}\n`);
+});
+
+process.on('unhandledRejection', (reason, promise) => {
+  fs.appendFileSync('/tmp/bot_errors.log', `${Date.now()} [MANAGER] Unhandled Rejection: ${reason}\n`);
+});
+
 
 async function main() {
     const db = new Database();
@@ -56,8 +67,15 @@ async function main() {
     });
 
 
-    manager.on('shardCreate', shard => console.log(`Launched shard ${shard.id}`));
+    manager.on('shardCreate', shard => {
+        shard.on('error', error => {
+            fs.appendFileSync('/tmp/bot_errors.log', `${Date.now()} [SHARD ${shard.id}]: ${error.stack || error}\n`);
+        });
+        console.log(`Launched shard ${shard.id}`));
+    
+}
 
+    
     manager.spawn();
 
     setupVoteServer();

--- a/index.js
+++ b/index.js
@@ -40,11 +40,19 @@ const fs = require('fs');
 
 // Catch errors at the manager level
 process.on('uncaughtException', (error) => {
-  fs.appendFileSync('/tmp/bot_errors.log', `${Date.now()} [MANAGER]: ${error.stack || error}\n`);
+  try {
+    fs.appendFileSync('/tmp/bot_errors.log', `${Date.now()} [MANAGER]: ${error.stack || error}\n`);
+  } catch (writeError) {
+    console.error('Failed to write error to log file:', writeError);
+  }
 });
 
 process.on('unhandledRejection', (reason, promise) => {
-  fs.appendFileSync('/tmp/bot_errors.log', `${Date.now()} [MANAGER] Unhandled Rejection: ${reason}\n`);
+  try {
+    fs.appendFileSync('/tmp/bot_errors.log', `${Date.now()} [MANAGER] Unhandled Rejection: ${reason}\n`);
+  } catch (writeError) {
+    console.error('Failed to write error to log file:', writeError);
+  }
 });
 
 
@@ -69,7 +77,9 @@ async function main() {
 
     manager.on('shardCreate', shard => {
         shard.on('error', error => {
-            fs.appendFileSync('/tmp/bot_errors.log', `${Date.now()} [SHARD ${shard.id}]: ${error.stack || error}\n`);
+            fs.appendFile('/tmp/bot_errors.log', `${Date.now()} [SHARD ${shard.id}]: ${error.stack || error}\n`, err => {
+                if (err) console.error('Failed to write shard error log:', err);
+            });
         });
         console.log(`Launched shard ${shard.id}`));
     

--- a/index.js
+++ b/index.js
@@ -40,19 +40,19 @@ const fs = require('fs');
 
 // Catch errors at the manager level
 process.on('uncaughtException', (error) => {
-  try {
-    fs.appendFileSync('/tmp/bot_errors.log', `${Date.now()} [MANAGER]: ${error.stack || error}\n`);
-  } catch (writeError) {
-    console.error('Failed to write error to log file:', writeError);
-  }
+  fs.appendFile('/tmp/bot_errors.log', `${new Date().toISOString()} [MANAGER]: ${error.stack || error}\n`, (writeError) => {
+    if (writeError) {
+      console.error('Failed to write error to log file:', writeError);
+    }
+  });
 });
 
 process.on('unhandledRejection', (reason, promise) => {
-  try {
-    fs.appendFileSync('/tmp/bot_errors.log', `${Date.now()} [MANAGER] Unhandled Rejection: ${reason}\n`);
-  } catch (writeError) {
-    console.error('Failed to write error to log file:', writeError);
-  }
+  fs.appendFile('/tmp/bot_errors.log', `${new Date().toISOString()} [MANAGER] Unhandled Rejection: ${reason}\n`, (writeError) => {
+    if (writeError) {
+      console.error('Failed to write error to log file:', writeError);
+    }
+  });
 });
 
 
@@ -77,13 +77,12 @@ async function main() {
 
     manager.on('shardCreate', shard => {
         shard.on('error', error => {
-            fs.appendFile('/tmp/bot_errors.log', `${Date.now()} [SHARD ${shard.id}]: ${error.stack || error}\n`, err => {
+            fs.appendFile('/tmp/bot_errors.log', `${new Date().toISOString()} [SHARD ${shard.id}]: ${error.stack || error}\n`, err => {
                 if (err) console.error('Failed to write shard error log:', err);
             });
         });
-        console.log(`Launched shard ${shard.id}`));
-    
-}
+        console.log(`Launched shard ${shard.id}`);
+    });
 
     
     manager.spawn();


### PR DESCRIPTION
Added error handling for uncaught exceptions and unhandled promise rejections, logging to '/tmp/bot_errors.log'. Also added error logging for shard events.